### PR TITLE
Removed unknown_integer inclusion in views

### DIFF
--- a/FSEParser_V4.0.py
+++ b/FSEParser_V4.0.py
@@ -1449,7 +1449,6 @@ def create_sqlite_db(self):
                 # Try to execute the query
                 cols = 'id_hex, \
                     node_id, \
-                    unknown_integer, \
                     fullpath, \
                     type, \
                     flags, \


### PR DESCRIPTION
When the views are created they have the `unknown_integer` field which is not carried into the `fsevents_sorted_by_event_id` table.
Using the `-q` flag therefore fails on report generation when the views are queried as there is a column mismatch.
This pr simply removes the `unknown_integer` field from the view creation.